### PR TITLE
Fix to make emoji work in push notifications

### DIFF
--- a/lib/houston/notification.rb
+++ b/lib/houston/notification.rb
@@ -99,7 +99,7 @@ module Houston
     end
 
     def payload_item
-      json = payload.to_json
+      json = JSON::dump(payload)
       [2, json.bytes.count, json].pack('cna*')
     end
 


### PR DESCRIPTION
For some reason, certain emoji get messed up when they are `to_json`ified. `JSON::dump` works though, as proposed on [this SO thread](http://stackoverflow.com/questions/5123993/json-encoding-wrongly-escaped-rails-3-ruby-1-9-2) for rails 2

Bad:

```
> puts "\xE2\x98\x95 \xE2\x98\x9D \xF0\x9F\x8E\xAE \xF0\x9F\x8D\x95".to_json
"\u2615 \u261d \uf3ae \uf355"
```

Good:

```
> puts JSON::dump("\xE2\x98\x95 \xE2\x98\x9D \xF0\x9F\x8E\xAE \xF0\x9F\x8D\x95")
"☕ ☝ 🎮 🍕"
```
